### PR TITLE
Disable alias attribute on macOS clang.

### DIFF
--- a/XenonRecomp/CMakeLists.txt
+++ b/XenonRecomp/CMakeLists.txt
@@ -19,6 +19,11 @@ target_link_libraries(XenonRecomp PRIVATE
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     target_compile_options(XenonRecomp PRIVATE -Wno-switch -Wno-unused-variable -Wno-null-arithmetic)
+
+    # alias attribute not supported on Apple.
+    if (NOT APPLE)
+        target_compile_definitions(XenonRecomp PRIVATE XENON_RECOMP_USE_ALIAS)
+    endif()
 endif()
 
 target_compile_definitions(XenonRecomp PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -2334,7 +2334,10 @@ bool Recompiler::Recompile(const Function& fn)
         name = fmt::format("sub_{}", fn.base);
     }
 
+#ifdef XENON_RECOMP_USE_ALIAS
     println("__attribute__((alias(\"__imp__{}\"))) PPC_WEAK_FUNC({});", name, name);
+#endif
+
     println("PPC_FUNC_IMPL(__imp__{}) {{", name);
     println("\tPPC_FUNC_PROLOGUE();");
 
@@ -2394,6 +2397,12 @@ bool Recompiler::Recompile(const Function& fn)
 #endif
 
     println("}}\n");
+
+#ifndef XENON_RECOMP_USE_ALIAS
+    println("PPC_WEAK_FUNC({}) {{", name);
+    println("\t__imp__{}(ctx, base);", name);
+    println("}}\n");
+#endif
 
     std::swap(out, tempString);
     if (localVariables.ctr)


### PR DESCRIPTION
Clang does not support the `alias` attribute for Darwin targets. In this case, just define a function body that calls the implementation.