### PR TITLE
Added Windows build instructions with MSYS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,23 @@ The project requires CMake 3.20 or later and Clang 18 or later to build. Since t
 
 Compilers other than Clang have not been tested and are not recommended, including for recompilation output. The project relies on compiler-specific intrinsics and techniques that may not function correctly on other compilers, and many optimization methods depend on Clang's code generation.
 
+### Linux
+
+**TODO**
+
+### Windows (Visual Studio)
+
 On Windows, you can use the clang-cl toolset and open the project in Visual Studio's CMake integration.
+
+### Windows (MSYS2)
+
+Alternatively, you can install [MSYS2](https://www.msys2.org/) and use the "MSYS2 CLANG64" environment to build the project.
+
+First, you need to install the necessary packages (`mingw-w64-clang-x86_64-cmake`, `mingw-w64-clang-x86_64-libc++` and `mingw-w64-x86_64-ninja`) with `pacman -S <package_name>`.
+
+Then, you can head into the cloned repo's directory (you can access your C drive by going into the `/c` folder inside of MSYS2), and execute the command `cmake -DCMAKE_BUILD_TYPE=Debug .`, which will generate a `build.ninja` file for the project.
+
+Finally, run the `ninja` command, and you should end up with compiled executables. Attempting to launch them will tell you about a missing `libc++.dll` file, which you can copy to your current folder with the `cp /clang64/bin/libc++.dll .` command.
 
 ## Special Thanks
 


### PR DESCRIPTION
Visual Studio always gave me trouble and I didn't feel like installing 8GB of Clang-related tools, I looked for alternatives and the MSYS2 solution seems to be a pretty quick and easy compromise to give people an environment with Clang.