### PR TITLE
Several XEX2 Loading Fixes

### DIFF
--- a/XenonUtils/xex.h
+++ b/XenonUtils/xex.h
@@ -245,13 +245,17 @@ inline const void* getOptHeaderPtr(const uint8_t* moduleBytes, uint32_t headerKe
         const Xex2OptHeader& optHeader = ((const Xex2OptHeader*)(xex2Header + 1))[i];
         if (optHeader.key == headerKey)
         {
-            if ((headerKey & 0xFF) == 0)
+            if((headerKey & 0xFF) == 0)
             {
-                return &optHeader.value;
+                return reinterpret_cast<const uint32_t *>(&optHeader.value);
+            }
+            else if ((headerKey & 0xFF) == 1)
+            {
+                return reinterpret_cast<const void *>(&optHeader.value);
             }
             else
             {
-                return &moduleBytes[optHeader.offset];
+                return reinterpret_cast<const void *>(reinterpret_cast<uintptr_t>(moduleBytes) + optHeader.offset);
             }
         }
     }


### PR DESCRIPTION
* Fixes loading .xex import table names when a name offset is not aligned to 4 bytes.
* Fixes loading .xex optional headers, adds missing case when the `header_key & 0xFF == 1`
* Fixes loading .xex base address and entry point to be the XEX2 base/entry to successfully resolve all import thunks.

Tested XenonAnalyse and XenonRecomp with several ripped retail games, devkit-exclusive/homebrew tools such as xbdm. XRPC, XEX Menu and Dashlaunch.