### PR TITLE
Fix the unsafe base address assumption.

### DIFF
--- a/XenonUtils/ppc_context.h
+++ b/XenonUtils/ppc_context.h
@@ -29,7 +29,7 @@
 #define PPC_EXTERN_FUNC(x) extern PPC_FUNC(x)
 #define PPC_WEAK_FUNC(x) __attribute__((weak,noinline)) PPC_FUNC(x)
 
-#define PPC_FUNC_PROLOGUE() __builtin_assume(((size_t)base & 0xFFFFFFFF) == 0)
+#define PPC_FUNC_PROLOGUE() __builtin_assume(((size_t)base & 0x1F) == 0)
 
 #ifndef PPC_LOAD_U8
 #define PPC_LOAD_U8(x) *(volatile uint8_t*)(base + (x))


### PR DESCRIPTION
This was causing undefined behavior in Unleashed Recompiled if VirtualAlloc failed to allocate at the hint address.