### PR TITLE
Better .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,13 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# IntelliJ IDEs
+.idea/
+
+# macOS metadata
+*.DS_Store
+
+# CMake Files
+**/cmake-build-debug
+**/CMakeCache.txt


### PR DESCRIPTION
Hides IntelliJ IDE files, macOS metadata, and some CMake files.