### PR TITLE
Fix bswap with MSVC compiler

### DIFF
--- a/XenonUtils/byteswap.h
+++ b/XenonUtils/byteswap.h
@@ -2,17 +2,30 @@
 
 #include <cassert>
 
+#if defined(_MSC_VER)  // MSVC
+#include <intrin.h>
+#define BSWAP16(x) _byteswap_ushort(x)
+#define BSWAP32(x) _byteswap_ulong(x)
+#define BSWAP64(x) _byteswap_uint64(x)
+#elif defined(__GNUC__) || defined(__clang__)  // GCC or Clang
+#define BSWAP16(x) __builtin_bswap16(x)
+#define BSWAP32(x) __builtin_bswap32(x)
+#define BSWAP64(x) __builtin_bswap64(x)
+#else
+#error "Unsupported compiler"
+#endif
+
 template<typename T>
 inline T ByteSwap(T value)
 {
     if constexpr (sizeof(T) == 1)
         return value;
     else if constexpr (sizeof(T) == 2)
-        return static_cast<T>(__builtin_bswap16(static_cast<uint16_t>(value)));
+        return static_cast<T>(BSWAP16(static_cast<uint16_t>(value)));
     else if constexpr (sizeof(T) == 4)
-        return static_cast<T>(__builtin_bswap32(static_cast<uint32_t>(value)));
+        return static_cast<T>(BSWAP32(static_cast<uint32_t>(value)));
     else if constexpr (sizeof(T) == 8)
-        return static_cast<T>(__builtin_bswap64(static_cast<uint64_t>(value)));
+        return static_cast<T>(BSWAP64(static_cast<uint64_t>(value)));
 
     assert(false && "Unexpected byte size.");
     return value;


### PR DESCRIPTION
Hi,

Quick compilation fix for MSVC. 
__builtin_bswap is for clang/GCC and _byteswap_ is for MSVC.

Cheers,
-Yohann