### PR TITLE
Created script for automatically generating function boundaries

### DIFF
--- a/Auto_Function_Parser.py
+++ b/Auto_Function_Parser.py
@@ -14,7 +14,7 @@ import re
 
 # Check if correct number of input arguments were given
 if len(sys.argv) != 4:
-    sys.exit("parser.py [IDA HTML] [XenonRecomp log] [Output TOML]")
+    sys.exit("Auto_Function_Parser.py [IDA HTML] [XenonRecomp log] [Output TOML]")
 
 # Filepath input arguments
 ida_html = sys.argv[1]

--- a/Auto_Function_Parser.py
+++ b/Auto_Function_Parser.py
@@ -40,7 +40,7 @@ with open(xenonrecomp_log, 'r') as file:
     # Read each line in the file
     for line in file: 
         # If this line describes an error, it has the address of a problematic switch statement
-        if re.search('ERROR: Switch case at ', line) != None:
+        if re.search('ERROR: Switch case at ', line):
             # Save the address as integer
             switch_addrs.append(line[switch_idx:switch_idx+8])
 
@@ -103,7 +103,7 @@ with open(ida_html, 'r') as file:
                 curr_addr = line[colon_idx+1:colon_idx+9]
 
                 # Check if this is the start of a function
-                if re.search('.text:'+curr_addr+' </span><span class="c[0-9]*">sub_'+curr_addr+'</span><span class="c[0-9]*">: *</span><span class="c[0-9]*"># [A-Z][A-Z][A-Z][A-Z] XREF:', line):
+                if re.search(r'\.text:'+curr_addr+' </span><span class="c[0-9]*">sub_'+curr_addr+'</span><span class="c[0-9]*">: *</span><span class="c[0-9]*"># [A-Z][A-Z][A-Z][A-Z] XREF:', line):
                     # Save current address as integer
                     curr_addr_int = int(curr_addr, 16)
 
@@ -131,7 +131,7 @@ with open(ida_html, 'r') as file:
                         add_function(curr_addr_int, None, 'sub')
 
                 # If this is a location
-                elif re.search('^\.text:'+curr_addr+' </span><span class="c[0-9]*">loc_'+curr_addr, line):
+                elif re.search(r'^\.text:'+curr_addr+' </span><span class="c[0-9]*">loc_'+curr_addr, line):
                     curr_addr_int = int(curr_addr, 16)
                     curr_funct = functs[num_functs-1]
                     # If previous address was a blr instruction
@@ -163,7 +163,7 @@ with open(ida_html, 'r') as file:
                             functs[num_functs-1][2].append(line[xref_idx+15:xref_idx+23])
 
                 # Check if this line is padding
-                elif num_functs > 0 and re.search('<span class="c[0-9]*">\.long </span><span class="c[0-9]*">0$', line):
+                elif num_functs > 0 and re.search(r'<span class="c[0-9]*">\.long </span><span class="c[0-9]*">0$', line):
                     # Convert current address to integer 
                     curr_addr_int = int(curr_addr, 16)
 
@@ -198,7 +198,7 @@ with open(ida_html, 'r') as file:
             # If not in .text
             else:
                 # If .text section header found
-                if re.search('<span class="c[0-9]*">\.section &quot;\.text&quot;', line) != None:
+                if re.search(r'<span class="c[0-9]*">\.section &quot;\.text&quot;', line):
                     in_text = True
 
 ##

--- a/Auto_Function_Parser.py
+++ b/Auto_Function_Parser.py
@@ -103,7 +103,7 @@ with open(ida_html, 'r') as file:
                 curr_addr = line[colon_idx+1:colon_idx+9]
 
                 # Check if this is the start of a function
-                if re.search('^\.text:'+curr_addr+' </span><span class="c[0-9]*">sub_'+curr_addr+'</span><span class="c[0-9]*">: *</span><span class="c[0-9]*"># [A-Z][A-Z][A-Z][A-Z] XREF:.*', line):
+                if re.search('.text:'+curr_addr+' </span><span class="c[0-9]*">sub_'+curr_addr+'</span><span class="c[0-9]*">: *</span><span class="c[0-9]*"># [A-Z][A-Z][A-Z][A-Z] XREF:', line):
                     # Save current address as integer
                     curr_addr_int = int(curr_addr, 16)
 

--- a/Auto_Function_Parser.py
+++ b/Auto_Function_Parser.py
@@ -252,11 +252,12 @@ if not debug:
     output_functs = list(set(tuple(funct) for funct in output_functs))
 
 # Make sure there are no functions with the same starting address but different lengths
-for i in range(len(output_functs)):
-    for j in range(i+1, len(output_functs)):
-        curr_funct_start = output_functs[i][0]
-        if curr_funct_start == output_functs[j][0]:
-            print(f"WARNING: {curr_funct_start} has multiple entries of different lengths, manually find correct one.")
+if not debug:
+    for i in range(len(output_functs)):
+        for j in range(i+1, len(output_functs)):
+            curr_funct_start = output_functs[i][0]
+            if curr_funct_start == output_functs[j][0]:
+                print(f"WARNING: {curr_funct_start} has multiple entries of different lengths, manually find correct one.")
 
 print(f"{len(output_functs)} functions found!")
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ functions = [
 
 You can define function boundaries explicitly using the `functions` property if XenonAnalyse fails to analyze them correctly, for example, with functions containing jump tables.
 
+You can automatically generate these using the FunctionParser.py script. You will need to create a HTML of your decompiled XEX with IDA using `File -> Produce File -> Create HTML File...` and save the terminal output from running XenonRecomp by appending `> [output log file path]` to the command.
+
+```
+python3 FunctionParser.py [input IDA HTML file path] [input XenonRecomp log file path] [output function list file path]
+```
+
 #### Invalid Instruction Skips
 
 ```toml

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,221 @@
+##
+## Searches for functions in .text that are referenced by functions in .pdata
+##
+## Input: 
+## Decompiled code - Created in IDA Pro 9.0SP1 with File -> Produce File -> Create HTML File...
+## CLI output from a XenonRecomp run - When trying to compile with XenonRecomp, use > to save the output from the terminal
+##
+## Output: 
+## XenonRecomp config - Function block for TOML to be inputted into XenonRecomp 
+##
+
+import sys
+import re
+
+# Check if correct number of input arguments were given
+if len(sys.argv) != 4:
+    sys.exit("parser.py [IDA HTML] [XenonRecomp log] [Output TOML]")
+
+# Filepath input arguments
+ida_html = sys.argv[1]
+xenonrecomp_log = sys.argv[2]
+output_file = sys.argv[3]
+
+##
+## Parse XenonRecomp log
+##
+
+# The starting index of the erroneous switch statement address in the XenonRecomp log
+switch_idx = 22
+
+# Initialize list to store erroneous switch statement addresses
+switch_addrs = []
+    
+print("Parsing XenonRecomp log...")
+# Import each line of XenonRecomp log
+with open(xenonrecomp_log, 'r') as file:
+    # Read each line in the file
+    for line in file: 
+        # If this line describes an error, it has the address of a problematic switch statement
+        if re.search('ERROR', line) != None:
+            # Save the address as integer
+            switch_addrs.append(line[switch_idx:switch_idx+8])
+
+# Save only unique addresses and sort
+switch_addrs = set(switch_addrs)
+
+##
+## Parse IDA HTML
+##
+
+# See if current function is referenced by the inputted comparison address 
+def compare_xref_addr(line, compare_addr):
+    # Get the address of the referencing function
+    xref_idx = line.find('CODE XREF: sub_')
+    # If there is not a referencing function or it is in a different file, this doesn't need to be verified
+    if xref_idx == -1:
+        return True
+    else:
+        xref = line[xref_idx+15:xref_idx+23]
+
+    # Check equality between XREF address and comparison address
+    return xref == compare_addr
+
+# Initialize list to store start and end of functions 
+functs = []
+
+# Count how many functions have been added
+num_functs = 0
+
+# Mark if we are in .text section
+in_text = False
+
+# Mark if we should end parsing
+end_parse = False
+
+# Initialize address of last padding to 0
+pad_addr = '00000000'
+
+# Import each line of decompiled code
+print("Parsing IDA HTML...")
+with open(ida_html, 'r') as file:
+    # Read each line in the file
+    for line in file:
+        if not end_parse:
+            # If in .text
+            if in_text:
+                # Get the current address
+                colon_idx = line.find(':')
+                curr_addr = line[colon_idx+1:colon_idx+9]
+
+                # Check if this is the start of a function
+                if re.search('^\.text:'+curr_addr+' </s pan><span class="c[0-9]*">sub_'+curr_addr, line):
+                    # Check if this is a new function and not part of a switch
+                    if num_functs > 0:
+                        # If the referencing function is not the last added function, then it is not part of a switch
+                        equal_xref = compare_xref_addr(line, functs[num_functs-1][0])
+                        if equal_xref:
+                            # Add this address as a new function
+                            functs.append([curr_addr, 0])
+                            num_functs = num_functs+1
+                            # Convert addresses to integer for comparison
+                            curr_addr_int = int(curr_addr, 16)
+                            pad_addr_int = int(pad_addr, 16)
+                            # If previous address was padding, end last function at the padding
+                            if curr_addr_int-4 == pad_addr_int:
+                                functs[num_functs-2][1] = pad_addr_int
+                            # Else, end last function as this address
+                            else:
+                                functs[num_functs-2][1] = curr_addr_int
+
+                    # If this is the first function to be added, don't need to check if it is part of a switch
+                    else:
+                        # Add this address as a new function
+                        functs.append([curr_addr, 0])
+                        num_functs = num_functs+1
+
+                # If this is not the start of a function
+                else:
+                    # Check if it is a nested loc_ or def_
+                    if re.search('^\.text:'+curr_addr+' </span><span class="c[0-9]*">[ld][oe][cf]_'+curr_addr, line):
+                        # If the referencing function is not the last added function, then it is not part of a switch
+                        if not compare_xref_addr(line, functs[num_functs-1][0]):
+                            # Add this address as a new function
+                            functs.append([curr_addr, 0])
+                            num_functs = num_functs+1
+                            # Convert addresses to integer for comparison
+                            curr_addr_int = int(curr_addr, 16)
+                            pad_addr_int = int(pad_addr, 16)
+                            # If previous address was padding, end last function at the padding
+                            if curr_addr_int-4 == pad_addr_int:
+                                functs[num_functs-2][1] = pad_addr_int
+                            # End the last function at the previous address
+                            else:
+                                functs[num_functs-2][1] = curr_addr_int
+                    
+                    # Check if this line is padding
+                    elif re.search('<span class="c[0-9]*">\.long </span><span class="c[0-9]*">0$', line):
+                        # Save address of most recently found padding
+                        pad_addr = curr_addr
+
+                    # Check if we are still in .text
+                    elif re.search('\.text:', line) == None:
+                        # If not, end parsing
+                            end_parse = True
+
+            # If not in .text
+            else:
+                # If .text section header found
+                if re.search('<span class="c[0-9]*">\.section &quot;\.text&quot;', line) != None:
+                    in_text = True
+
+##
+## Find .text functions that are referenced by .pdata functions
+##
+
+# Initialize list for functions that need to be added to toml
+output_functs = []
+
+# Look for related functions for every unique errored switch statement
+print("Searching for needed functions...")
+for switch_addr in switch_addrs:
+    # Start looking at first subroutine
+    curr_funct_idx = 0
+
+    # Save current switch statement address as integer
+    switch_addr_int = int(switch_addr, 16)
+
+    # The related function for this switch statement has not been found yet
+    search_for_funct = True
+
+    # Start search for function relating to switch statement
+    while(search_for_funct):
+        curr_funct = functs[curr_funct_idx]
+        # If switch address is after this function's start
+        curr_funct_start = int(curr_funct[0], 16)
+        if(switch_addr_int > curr_funct_start):
+            # If switch address is before this function's end
+            curr_funct_end = curr_funct[1]
+            if(switch_addr_int <= curr_funct_end):
+                # Save current function's start address and the function's length
+                output_functs.append([hex(curr_funct_start), hex(curr_funct_end-curr_funct_start)])
+                # Don't need to continue search for this switch statement
+                search_for_funct = False
+
+            # Look in next function
+            curr_funct_idx = curr_funct_idx + 1
+
+        # Related function was not found
+        else:
+            print(f"WARNING: Function relating to {switch_addr} not found")
+            # Don't need to continue search for this switch statement
+            search_for_funct = False
+
+print(f"{len(output_functs)} functions found!")                
+
+# Create formatted string to export to TOML
+output_str = "functions = ["
+
+# Append all function addresses and lengths to formatted string
+for funct in output_functs:
+    # Format hex to uppercase 
+    curr_funct_start = '0x'+funct[0][2:].upper()
+    curr_funct_end = '0x'+funct[1][2:].upper()
+
+    # Format function 
+    curr_funct = "\n    { address = "+curr_funct_start+", size = "+curr_funct_end+" },"
+
+    # Add to complete output string
+    output_str = output_str+curr_funct
+
+# Delete last comma
+output_str = output_str[:len(output_str)-1]
+
+# Add last bracket
+output_str = output_str+"\n]"
+
+# Output to file
+with open(output_file, "w") as file:
+    file.write(output_str)
+
+

--- a/parser.py
+++ b/parser.py
@@ -89,12 +89,11 @@ with open(ida_html, 'r') as file:
                 curr_addr = line[colon_idx+1:colon_idx+9]
 
                 # Check if this is the start of a function
-                if re.search('^\.text:'+curr_addr+' </s pan><span class="c[0-9]*">sub_'+curr_addr, line):
+                if re.search('^\.text:'+curr_addr+' </span><span class="c[0-9]*">sub_'+curr_addr, line):
                     # Check if this is a new function and not part of a switch
                     if num_functs > 0:
                         # If the referencing function is not the last added function, then it is not part of a switch
-                        equal_xref = compare_xref_addr(line, functs[num_functs-1][0])
-                        if equal_xref:
+                        if not compare_xref_addr(line, functs[num_functs-1][0]):
                             # Add this address as a new function
                             functs.append([curr_addr, 0])
                             num_functs = num_functs+1


### PR DESCRIPTION
Using the decompiled code exported from IDA as a HTML and the switch addresses that cause errors when using XenonRecomp (I deleted every line in SWA.toml after 'setjmp_address', (although I had to keep the invalid address block, else XenonRecomp wouldn't run), then ran XenonRecomp and saved the CLI output to a file), I wrote a script that reproduces 39/42 of the function boundaries in UnleashedRecomp. Below is the output of the script:

```
functions = [
    { address = 0x830B7DD0, size = 0x74 },
    { address = 0x82F098C0, size = 0x19C },
    { address = 0x826ABB70, size = 0x70 },
    { address = 0x8319ED58, size = 0x98 },
    { address = 0x82456DC8, size = 0xD4 },
    { address = 0x82DE36A8, size = 0x5C },
    { address = 0x82F852A0, size = 0xCC },
    { address = 0x82C980E8, size = 0x110 },
    { address = 0x82DE38A0, size = 0x16C },
    { address = 0x82EF5C38, size = 0x64 },
    { address = 0x82F1D668, size = 0x1E8 },
    { address = 0x82EE2D08, size = 0x154 },
    { address = 0x82F08730, size = 0x2B0 },
    { address = 0x82455E70, size = 0x84 },
    { address = 0x82E97E50, size = 0x84 },
    { address = 0x831530C8, size = 0x258 },
    { address = 0x82F13980, size = 0xF4 },
    { address = 0x82DE3708, size = 0x198 },
    { address = 0x82893088, size = 0x45C },
    { address = 0x831539E0, size = 0xD0 },
    { address = 0x82C49540, size = 0x114 },
    { address = 0x82E86770, size = 0x98 },
    { address = 0x83180700, size = 0x74 },
    { address = 0x83168F18, size = 0x254 },
    { address = 0x830DADA0, size = 0x150 },
    { address = 0x82DE3640, size = 0x64 },
    { address = 0x82F25FD8, size = 0x240 },
    { address = 0x82D9AC08, size = 0x78 },
    { address = 0x831487D0, size = 0xD4 },
    { address = 0x83168940, size = 0x100 },
    { address = 0x82CF7080, size = 0x80 },
    { address = 0x8317CD30, size = 0x50 },
    { address = 0x83168B70, size = 0x128 },
    { address = 0x82EF5D78, size = 0x3F8 },
    { address = 0x82DE35D8, size = 0x68 },
    { address = 0x83168A48, size = 0x11C },
    { address = 0x824E7EF0, size = 0x98 },
    { address = 0x8316C678, size = 0x78 },
    { address = 0x82F22908, size = 0x20C }
]
```

I verified these functions were correct using sort and diff in the Linux terminal. The only difference is the order, and that it is missing the following three functions:
```
{ address = 0x824E7F28, size = 0x60 }
{ address = 0x8305D168, size = 0x278 }
{ address = 0x831B0BA0, size = 0xA0 }
```
