### PR TITLE
Search for and print out register save/load locations

### DIFF
--- a/XenonAnalyse/main.cpp
+++ b/XenonAnalyse/main.cpp
@@ -1,11 +1,11 @@
+#include "fmt/xchar.h"
+#include "function.h"
+#include <algorithm>
 #include <cassert>
-#include <iterator>
-#include <file.h>
 #include <disasm.h>
+#include <file.h>
 #include <image.h>
 #include <xbox.h>
-#include <fmt/core.h>
-#include "function.h"
 
 #define SWITCH_ABSOLUTE 0
 #define SWITCH_COMPUTED 1
@@ -20,6 +20,59 @@ struct SwitchTable
     uint32_t r{};
     uint32_t type{};
 };
+
+static const std::vector<uint8_t> RESTGPRLR_14 = { 0xe9, 0xc1, 0xff, 0x68 };
+static const std::vector<uint8_t> SAVEGPRLR_14 = { 0xf9, 0xc1, 0xff, 0x68 };
+static const std::vector<uint8_t> RESTFPR_14 = { 0xc9, 0xcc, 0xff, 0x70 };
+static const std::vector<uint8_t> SAVEFPR_14 = { 0xd9, 0xcc, 0xff, 0x70 };
+static const std::vector<uint8_t> RESTVMX_14 = { 0x39, 0x60, 0xfe, 0xe0, 0x7d, 0xcb, 0x60, 0xce };
+static const std::vector<uint8_t> SAVEVMX_14 = { 0x39, 0x60, 0xfe, 0xe0, 0x7d, 0xcb, 0x61, 0xce };
+static const std::vector<uint8_t> RESTVMX_64 = { 0x39, 0x60, 0xfc, 0x00, 0x10, 0x0b, 0x60, 0xcb };
+static const std::vector<uint8_t> SAVEVMX_64 = { 0x39, 0x60, 0xfc, 0x00, 0x10, 0x0b, 0x61, 0xcb };
+
+uint32_t BytePatternSearch(uint8_t* data, uint32_t size, uint32_t baseAddress, const std::vector<uint8_t>& pattern)
+{
+    auto result = std::search(data, data + size, pattern.begin(), pattern.end());
+    if (result != data + size) {
+        return baseAddress + std::distance(data, result);
+    }
+
+    return UINT32_MAX;
+}
+
+void RegisterFunctionsSearch(Image& image)
+{
+    uint32_t baseAddress = UINT32_MAX;
+
+    for (const auto& section : image.sections) {
+        if (section.name == ".text") {
+            baseAddress = section.base;
+
+            if (baseAddress == UINT32_MAX) {
+                fmt::println("Could not find \".text\" section.");
+                return;
+            }
+
+            uint32_t restgprlr_14 = BytePatternSearch(section.data, section.size, baseAddress, RESTGPRLR_14);
+            uint32_t savegprlr_14 = BytePatternSearch(section.data, section.size, baseAddress, SAVEGPRLR_14);
+            uint32_t restfpr_14 = BytePatternSearch(section.data, section.size, baseAddress, RESTFPR_14);
+            uint32_t savefpr_14 = BytePatternSearch(section.data, section.size, baseAddress, SAVEFPR_14);
+            uint32_t restvmx_14 = BytePatternSearch(section.data, section.size, baseAddress, RESTVMX_14);
+            uint32_t savevmx_14 = BytePatternSearch(section.data, section.size, baseAddress, SAVEVMX_14);
+            uint32_t restvmx_64 = BytePatternSearch(section.data, section.size, baseAddress, RESTVMX_64);
+            uint32_t savevmx_64 = BytePatternSearch(section.data, section.size, baseAddress, SAVEVMX_64);
+
+            fmt::println("restgprlr_14_address = 0x{:X}", restgprlr_14);
+            fmt::println("savegprlr_14_address = 0x{:X}", savegprlr_14);
+            fmt::println("restfpr_14_address = 0x{:X}", restfpr_14);
+            fmt::println("savefpr_14_address = 0x{:X}", savefpr_14);
+            fmt::println("restvmx_14_address = 0x{:X}", restvmx_14);
+            fmt::println("savevmx_14_address = 0x{:X}", savevmx_14);
+            fmt::println("restvmx_64_address = 0x{:X}", restvmx_64);
+            fmt::println("savevmx_64_address = 0x{:X}", savevmx_64);
+        }
+    }
+}
 
 void ReadTable(Image& image, SwitchTable& table)
 {
@@ -191,6 +244,8 @@ int main(int argc, char** argv)
 
     const auto file = LoadFile(argv[1]);
     auto image = Image::ParseImage(file.data(), file.size());
+
+    RegisterFunctionsSearch(image);
 
     auto printTable = [&](const SwitchTable& table)
         {


### PR DESCRIPTION
Automatically searches the XEX for the addresses for register save/load functions. These are not provided as a guarantee that they are correct, and the user should be expected to verify them.

`std::search` will only return the first match, which should only be one, but it won't warn if more potentially exist.

If the pattern is not matched anywhere in the binary `UINT32_MAX` will be returned.