### PR TITLE
Fix bitmask of VD3D0 operand

### DIFF
--- a/thirdparty/disasm/ppc-dis.c
+++ b/thirdparty/disasm/ppc-dis.c
@@ -840,7 +840,7 @@ const struct powerpc_operand powerpc_operands[] =
                            { 8, 0, insert_vperm, extract_vperm, 0 },
                           
                           #define VD3D0 VPERM128 + 1
-                           { 3, 18, NULL, NULL, 0 },
+                           { 7, 18, NULL, NULL, 0 },
                           
                           #define VD3D1 VD3D0 + 1
                            { 3, 16, NULL, NULL, 0 },


### PR DESCRIPTION
The VD3D0 operand of the vpkd3d128 instruction is a 3-bit value and may therefore take a bitmask of `0b111`. This was noticed during work towards recompiling Ninja Gaiden 2 and was confirmed by checking the respective implementation in Xenia.