### PR TITLE
Added extra vpkd3d128 cases (5,2,2 and other 0,1)

### DIFF
--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -2022,16 +2022,16 @@ bool Recompiler::Recompile(
 		// Strip sign from source
 		println("\t{}.u32 = ({}.u32[{}]&0x7FFFFFFF);", temp(), v(insn.operands[1]), i);
 		// If |source| is > 65504, clamp output to 0x7FFF, else save 8 exponent bits 
-                println("\t{}.u8[0] = ({}.f32 != {}.f32) || ({}.f32 > 65504.0f) ? 0xFF : (({}.u32[{}]&0x7f800000)>>23);", vTemp(), temp(), temp(), temp(), v(insn.operands[1]), i);
+		println("\t{0}.u8[0] = ({1}.f32 != {1}.f32) || ({1}.f32 > 65504.0f) ? 0xFF : (({2}.u32[{3}]&0x7f800000)>>23);", vTemp(), temp(), v(insn.operands[1]), i);
 		// If 8 exponent bits were saved, it can only be 0x8E at most
 		// If saved, save first 10 bits of mantissa
-		println("\t{}.u16[1] = {}.u8[0] != 0xFF ? (({}.u32[{}]&0x7FE000)>>13) : 0x0;", vTemp(), vTemp(), v(insn.operands[1]), i);
+		println("\t{}.u16 = {}.u8[0] != 0xFF ? (({}.u32[{}]&0x7FE000)>>13) : 0x0;", temp(), vTemp(), v(insn.operands[1]), i);
 		// If saved and > 127-15, exponent is converted from 8 to 5-bit by subtracting 0x70
 		// If saved but not > 127-15, clamp exponent at 0, add 0x400 to mantissa and shift right by (0x71-exponent)
 		// If right shift is greater than 31 bits, manually clamp mantissa to 0 or else the output of the shift will be wrong
-                println("\t{}.u16 = {}.u8[0] != 0xFF ? ({}.u8[0] > 0x70 ? ((({}.u8[0]-0x70)<<10)+{}.u16[1]) : (0x71-{}.u8[0] > 31 ? 0x0 : ((0x400+{}.u16[1])>>(0x71-{}.u8[0])))) : 0x7FFF;", temp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp());
+		println("\t{0}.u16[{1}] = {2}.u8[0] != 0xFF ? ({2}.u8[0] > 0x70 ? ((({2}.u8[0]-0x70)<<10)+{3}.u16) : (0x71-{2}.u8[0] > 31 ? 0x0 : ((0x400+{3}.u16)>>(0x71-{2}.u8[0])))) : 0x7FFF;", v(insn.operands[0]), i+4, vTemp(), temp());
 		// Add back original sign
-                println("\t{}.u16[{}] = (({}.u32[{}]&0x80000000)>>16)+{}.u16;", v(insn.operands[0]), i+4, v(insn.operands[1]), i, temp());
+		println("\t{}.u16[{}] |= (({}.u32[{}]&0x80000000)>>16);", v(insn.operands[0]), i+4, v(insn.operands[1]), i);
             }
             break;
 

--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -2014,7 +2014,7 @@ bool Recompiler::Recompile(
             break;
 
         case 5: // float16_4
-            if (insn.operands[3] != 2)
+            if (insn.operands[3] != 2 || insn.operands[4] > 2)
                 fmt::println("Unexpected float16_4 pack instruction at {:X}", base);
 
             for (size_t i = 0; i < 4; i++)

--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -2019,18 +2019,18 @@ bool Recompiler::Recompile(
 
             for (size_t i = 0; i < 4; i++)
             {
-		// Strip sign from source
-		println("\t{}.u32 = ({}.u32[{}]&0x7FFFFFFF);", temp(), v(insn.operands[1]), i);
-		// If |source| is > 65504, clamp output to 0x7FFF, else save 8 exponent bits 
+		        // Strip sign from source
+		        println("\t{}.u32 = ({}.u32[{}]&0x7FFFFFFF);", temp(), v(insn.operands[1]), i);
+		        // If |source| is > 65504, clamp output to 0x7FFF, else save 8 exponent bits 
                 println("\t{}.u8[0] = ({}.f32 != {}.f32) || ({}.f32 > 65504.0f) ? 0xFF : (({}.u32[{}]&0x7f800000)>>23);", vTemp(), temp(), temp(), temp(), v(insn.operands[1]), i);
-		// If 8 exponent bits were saved, it can only be 0x8E at most
-		// If saved, save first 10 bits of mantissa
-		println("\t{}.u16[1] = {}.u8[0] != 0xFF ? (({}.u32[{}]&0x7FE000)>>13) : 0x0;", vTemp(), vTemp(), v(insn.operands[1]), i);
-		// If saved and > 127-15, exponent is converted from 8 to 5-bit by subtracting 0x70
-		// If saved but not > 127-15, clamp exponent at 0, add 0x400 to mantissa and shift right by (0x71-exponent)
-		// If right shift is greater than 31 bits, manually clamp mantissa to 0 or else the output of the shift will be wrong
+		        // If 8 exponent bits were saved, it can only be 0x8E at most
+		        // If saved, save first 10 bits of mantissa
+		        println("\t{}.u16[1] = {}.u8[0] != 0xFF ? (({}.u32[{}]&0x7FE000)>>13) : 0x0;", vTemp(), vTemp(), v(insn.operands[1]), i);
+		        // If saved and > 127-15, exponent is converted from 8 to 5-bit by subtracting 0x70
+		        // If saved but not > 127-15, clamp exponent at 0, add 0x400 to mantissa and shift right by (0x71-exponent)
+		        // If right shift is greater than 31 bits, manually clamp mantissa to 0 or else the output of the shift will be wrong
                 println("\t{}.u16 = {}.u8[0] != 0xFF ? ({}.u8[0] > 0x70 ? ((({}.u8[0]-0x70)<<10)+{}.u16[1]) : (0x71-{}.u8[0] > 31 ? 0x0 : ((0x400+{}.u16[1])>>(0x71-{}.u8[0])))) : 0x7FFF;", temp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp());
-		// Add back original sign
+		        // Add back original sign
                 println("\t{}.u16[{}] = (({}.u32[{}]&0x80000000)>>16)+{}.u16;", v(insn.operands[0]), i+4, v(insn.operands[1]), i, temp());
             }
             break;

--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -2030,7 +2030,7 @@ bool Recompiler::Recompile(
 		// If saved but not > 127-15, clamp exponent at 0, add 0x400 to mantissa and shift right by (0x71-exponent)
 		// If right shift is greater than 31 bits, manually clamp mantissa to 0 or else the output of the shift will be wrong
                 println("\t{}.u16 = {}.u8[0] != 0xFF ? ({}.u8[0] > 0x70 ? ((({}.u8[0]-0x70)<<10)+{}.u16[1]) : (0x71-{}.u8[0] > 31 ? 0x0 : ((0x400+{}.u16[1])>>(0x71-{}.u8[0])))) : 0x7FFF;", temp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp());
-		        // Add back original sign
+		// Add back original sign
                 println("\t{}.u16[{}] = (({}.u32[{}]&0x80000000)>>16)+{}.u16;", v(insn.operands[0]), i+4, v(insn.operands[1]), i, temp());
             }
             break;

--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -2014,7 +2014,7 @@ bool Recompiler::Recompile(
             break;
 
         case 5: // float16_4
-            if (insn.operands[3] != 2 || insn.operands[4] != 2)
+            if (insn.operands[3] != 2)
                 fmt::println("Unexpected float16_4 pack instruction at {:X}", base);
 
             for (size_t i = 0; i < 4; i++)
@@ -2029,9 +2029,9 @@ bool Recompiler::Recompile(
         		// If saved and > 127-15, exponent is converted from 8 to 5-bit by subtracting 0x70
         		// If saved but not > 127-15, clamp exponent at 0, add 0x400 to mantissa and shift right by (0x71-exponent)
         		// If right shift is greater than 31 bits, manually clamp mantissa to 0 or else the output of the shift will be wrong
-        		println("\t{0}.u16[{1}] = {2}.u8[0] != 0xFF ? ({2}.u8[0] > 0x70 ? ((({2}.u8[0]-0x70)<<10)+{3}.u16) : (0x71-{2}.u8[0] > 31 ? 0x0 : ((0x400+{3}.u16)>>(0x71-{2}.u8[0])))) : 0x7FFF;", v(insn.operands[0]), i+4, vTemp(), temp());
+        		println("\t{0}.u16[{1}] = {2}.u8[0] != 0xFF ? ({2}.u8[0] > 0x70 ? ((({2}.u8[0]-0x70)<<10)+{3}.u16) : (0x71-{2}.u8[0] > 31 ? 0x0 : ((0x400+{3}.u16)>>(0x71-{2}.u8[0])))) : 0x7FFF;", v(insn.operands[0]), i+(2*insn.operands[4]), vTemp(), temp());
         		// Add back original sign
-        		println("\t{}.u16[{}] |= (({}.u32[{}]&0x80000000)>>16);", v(insn.operands[0]), i+4, v(insn.operands[1]), i);
+        		println("\t{}.u16[{}] |= (({}.u32[{}]&0x80000000)>>16);", v(insn.operands[0]), i+(2*insn.operands[4]), v(insn.operands[1]), i);
             }
             break;
 

--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -2019,19 +2019,19 @@ bool Recompiler::Recompile(
 
             for (size_t i = 0; i < 4; i++)
             {
-		// Strip sign from source
-		println("\t{}.u32 = ({}.u32[{}]&0x7FFFFFFF);", temp(), v(insn.operands[1]), i);
-		// If |source| is > 65504, clamp output to 0x7FFF, else save 8 exponent bits 
-		println("\t{0}.u8[0] = ({1}.f32 != {1}.f32) || ({1}.f32 > 65504.0f) ? 0xFF : (({2}.u32[{3}]&0x7f800000)>>23);", vTemp(), temp(), v(insn.operands[1]), i);
-		// If 8 exponent bits were saved, it can only be 0x8E at most
-		// If saved, save first 10 bits of mantissa
-		println("\t{}.u16 = {}.u8[0] != 0xFF ? (({}.u32[{}]&0x7FE000)>>13) : 0x0;", temp(), vTemp(), v(insn.operands[1]), i);
-		// If saved and > 127-15, exponent is converted from 8 to 5-bit by subtracting 0x70
-		// If saved but not > 127-15, clamp exponent at 0, add 0x400 to mantissa and shift right by (0x71-exponent)
-		// If right shift is greater than 31 bits, manually clamp mantissa to 0 or else the output of the shift will be wrong
-		println("\t{0}.u16[{1}] = {2}.u8[0] != 0xFF ? ({2}.u8[0] > 0x70 ? ((({2}.u8[0]-0x70)<<10)+{3}.u16) : (0x71-{2}.u8[0] > 31 ? 0x0 : ((0x400+{3}.u16)>>(0x71-{2}.u8[0])))) : 0x7FFF;", v(insn.operands[0]), i+4, vTemp(), temp());
-		// Add back original sign
-		println("\t{}.u16[{}] |= (({}.u32[{}]&0x80000000)>>16);", v(insn.operands[0]), i+4, v(insn.operands[1]), i);
+        		// Strip sign from source
+        		println("\t{}.u32 = ({}.u32[{}]&0x7FFFFFFF);", temp(), v(insn.operands[1]), i);
+        		// If |source| is > 65504, clamp output to 0x7FFF, else save 8 exponent bits 
+        		println("\t{0}.u8[0] = ({1}.f32 != {1}.f32) || ({1}.f32 > 65504.0f) ? 0xFF : (({2}.u32[{3}]&0x7f800000)>>23);", vTemp(), temp(), v(insn.operands[1]), i);
+        		// If 8 exponent bits were saved, it can only be 0x8E at most
+        		// If saved, save first 10 bits of mantissa
+        		println("\t{}.u16 = {}.u8[0] != 0xFF ? (({}.u32[{}]&0x7FE000)>>13) : 0x0;", temp(), vTemp(), v(insn.operands[1]), i);
+        		// If saved and > 127-15, exponent is converted from 8 to 5-bit by subtracting 0x70
+        		// If saved but not > 127-15, clamp exponent at 0, add 0x400 to mantissa and shift right by (0x71-exponent)
+        		// If right shift is greater than 31 bits, manually clamp mantissa to 0 or else the output of the shift will be wrong
+        		println("\t{0}.u16[{1}] = {2}.u8[0] != 0xFF ? ({2}.u8[0] > 0x70 ? ((({2}.u8[0]-0x70)<<10)+{3}.u16) : (0x71-{2}.u8[0] > 31 ? 0x0 : ((0x400+{3}.u16)>>(0x71-{2}.u8[0])))) : 0x7FFF;", v(insn.operands[0]), i+4, vTemp(), temp());
+        		// Add back original sign
+        		println("\t{}.u16[{}] |= (({}.u32[{}]&0x80000000)>>16);", v(insn.operands[0]), i+4, v(insn.operands[1]), i);
             }
             break;
 

--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -2019,16 +2019,16 @@ bool Recompiler::Recompile(
 
             for (size_t i = 0; i < 4; i++)
             {
-		        // Strip sign from source
-		        println("\t{}.u32 = ({}.u32[{}]&0x7FFFFFFF);", temp(), v(insn.operands[1]), i);
-		        // If |source| is > 65504, clamp output to 0x7FFF, else save 8 exponent bits 
+		// Strip sign from source
+		println("\t{}.u32 = ({}.u32[{}]&0x7FFFFFFF);", temp(), v(insn.operands[1]), i);
+		// If |source| is > 65504, clamp output to 0x7FFF, else save 8 exponent bits 
                 println("\t{}.u8[0] = ({}.f32 != {}.f32) || ({}.f32 > 65504.0f) ? 0xFF : (({}.u32[{}]&0x7f800000)>>23);", vTemp(), temp(), temp(), temp(), v(insn.operands[1]), i);
-		        // If 8 exponent bits were saved, it can only be 0x8E at most
-		        // If saved, save first 10 bits of mantissa
-		        println("\t{}.u16[1] = {}.u8[0] != 0xFF ? (({}.u32[{}]&0x7FE000)>>13) : 0x0;", vTemp(), vTemp(), v(insn.operands[1]), i);
-		        // If saved and > 127-15, exponent is converted from 8 to 5-bit by subtracting 0x70
-		        // If saved but not > 127-15, clamp exponent at 0, add 0x400 to mantissa and shift right by (0x71-exponent)
-		        // If right shift is greater than 31 bits, manually clamp mantissa to 0 or else the output of the shift will be wrong
+		// If 8 exponent bits were saved, it can only be 0x8E at most
+		// If saved, save first 10 bits of mantissa
+		println("\t{}.u16[1] = {}.u8[0] != 0xFF ? (({}.u32[{}]&0x7FE000)>>13) : 0x0;", vTemp(), vTemp(), v(insn.operands[1]), i);
+		// If saved and > 127-15, exponent is converted from 8 to 5-bit by subtracting 0x70
+		// If saved but not > 127-15, clamp exponent at 0, add 0x400 to mantissa and shift right by (0x71-exponent)
+		// If right shift is greater than 31 bits, manually clamp mantissa to 0 or else the output of the shift will be wrong
                 println("\t{}.u16 = {}.u8[0] != 0xFF ? ({}.u8[0] > 0x70 ? ((({}.u8[0]-0x70)<<10)+{}.u16[1]) : (0x71-{}.u8[0] > 31 ? 0x0 : ((0x400+{}.u16[1])>>(0x71-{}.u8[0])))) : 0x7FFF;", temp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp(), vTemp());
 		        // Add back original sign
                 println("\t{}.u16[{}] = (({}.u32[{}]&0x80000000)>>16)+{}.u16;", v(insn.operands[0]), i+4, v(insn.operands[1]), i, temp());


### PR DESCRIPTION
For some reason the whitespace doesn't show correctly in Github but the rawfile has the right whitespace. Used with the NG2_MoreInstructions branch because it's needed for NG2. Verified against Xenia with some vpkd3d128(5,2,2) calls in NG2, not tested when using without additional NG2/BBB instructions and simde. Uploaded PR for visibility