### PR TITLE
[recompiler] Implement `frsqrte`

### DIFF
--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -1000,6 +1000,11 @@ bool Recompiler::Recompile(
         println("\t{}.f64 = sqrt({}.f64);", f(insn.operands[0]), f(insn.operands[1]));
         break;
 
+	case PPC_INST_FRSQRTE:
+        printSetFlushMode(false);
+        println("\t{}.f64 = 1.0 / sqrt({}.f64);", f(insn.operands[0]), f(insn.operands[1]));
+        break;
+
     case PPC_INST_FSQRTS:
         printSetFlushMode(false);
         println("\t{}.f64 = double(float(sqrt({}.f64)));", f(insn.operands[0]), f(insn.operands[1]));


### PR DESCRIPTION
A quick and dirty implementation of the `frsqrte` instruction via `std::sqrt`. If this needs more work (e.g., handling edge cases like divzero according to the IBM spec), please let me know.