### PR TITLE
Port some fixes from MarathonRecomp

### DIFF
--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -438,7 +438,7 @@ bool Recompiler::Recompile(
     auto printMidAsmHook = [&]()
         {
             bool returnsBool = midAsmHook->second.returnOnFalse || midAsmHook->second.returnOnTrue ||
-                midAsmHook->second.jumpAddressOnFalse != NULL || midAsmHook->second.jumpAddressOnTrue != NULL;
+                midAsmHook->second.jumpAddressOnFalse != 0 || midAsmHook->second.jumpAddressOnTrue != 0;
 
             print("\t");
             if (returnsBool)
@@ -489,7 +489,7 @@ bool Recompiler::Recompile(
 
                 if (midAsmHook->second.returnOnTrue)
                     println("\t\treturn;");
-                else if (midAsmHook->second.jumpAddressOnTrue != NULL)
+                else if (midAsmHook->second.jumpAddressOnTrue != 0)
                     println("\t\tgoto loc_{:X};", midAsmHook->second.jumpAddressOnTrue);
 
                 println("\t}}");
@@ -498,7 +498,7 @@ bool Recompiler::Recompile(
 
                 if (midAsmHook->second.returnOnFalse)
                     println("\t\treturn;");
-                else if (midAsmHook->second.jumpAddressOnFalse != NULL)
+                else if (midAsmHook->second.jumpAddressOnFalse != 0)
                     println("\t\tgoto loc_{:X};", midAsmHook->second.jumpAddressOnFalse);
 
                 println("\t}}");
@@ -509,7 +509,7 @@ bool Recompiler::Recompile(
 
                 if (midAsmHook->second.ret)
                     println("\treturn;");
-                else if (midAsmHook->second.jumpAddress != NULL)
+                else if (midAsmHook->second.jumpAddress != 0)
                     println("\tgoto loc_{:X};", midAsmHook->second.jumpAddress);
             }
         };
@@ -2314,7 +2314,7 @@ bool Recompiler::Recompile(const Function& fn)
         if (midAsmHook != config.midAsmHooks.end())
         {
             if (midAsmHook->second.returnOnFalse || midAsmHook->second.returnOnTrue ||
-                midAsmHook->second.jumpAddressOnFalse != NULL || midAsmHook->second.jumpAddressOnTrue != NULL)
+                midAsmHook->second.jumpAddressOnFalse != 0 || midAsmHook->second.jumpAddressOnTrue != 0)
             {
                 print("extern bool ");
             }
@@ -2361,11 +2361,11 @@ bool Recompiler::Recompile(const Function& fn)
 
             println(");\n");
 
-            if (midAsmHook->second.jumpAddress != NULL)
+            if (midAsmHook->second.jumpAddress != 0)
                 labels.emplace(midAsmHook->second.jumpAddress);       
-            if (midAsmHook->second.jumpAddressOnTrue != NULL)
+            if (midAsmHook->second.jumpAddressOnTrue != 0)
                 labels.emplace(midAsmHook->second.jumpAddressOnTrue);    
-            if (midAsmHook->second.jumpAddressOnFalse != NULL)
+            if (midAsmHook->second.jumpAddressOnFalse != 0)
                 labels.emplace(midAsmHook->second.jumpAddressOnFalse);
         }
     }

--- a/XenonRecomp/recompiler_config.cpp
+++ b/XenonRecomp/recompiler_config.cpp
@@ -115,16 +115,16 @@ void RecompilerConfig::Load(const std::string_view& configFilePath)
             midAsmHook.jumpAddressOnTrue = table["jump_address_on_true"].value_or(0u);
             midAsmHook.jumpAddressOnFalse = table["jump_address_on_false"].value_or(0u);
 
-            if ((midAsmHook.ret && midAsmHook.jumpAddress != NULL) ||
-                (midAsmHook.returnOnTrue && midAsmHook.jumpAddressOnTrue != NULL) ||
-                (midAsmHook.returnOnFalse && midAsmHook.jumpAddressOnFalse != NULL))
+            if ((midAsmHook.ret && midAsmHook.jumpAddress != 0) ||
+                (midAsmHook.returnOnTrue && midAsmHook.jumpAddressOnTrue != 0) ||
+                (midAsmHook.returnOnFalse && midAsmHook.jumpAddressOnFalse != 0))
             {
                 fmt::println("{}: can't return and jump at the same time", midAsmHook.name);
             }
 
-            if ((midAsmHook.ret || midAsmHook.jumpAddress != NULL) &&
-                (midAsmHook.returnOnFalse != NULL || midAsmHook.returnOnTrue != NULL ||
-                    midAsmHook.jumpAddressOnFalse != NULL || midAsmHook.jumpAddressOnTrue != NULL))
+            if ((midAsmHook.ret || midAsmHook.jumpAddress != 0) &&
+                (midAsmHook.returnOnFalse != 0 || midAsmHook.returnOnTrue != 0 ||
+                    midAsmHook.jumpAddressOnFalse != 0 || midAsmHook.jumpAddressOnTrue != 0))
             {
                 fmt::println("{}: can't mix direct and conditional return/jump", midAsmHook.name);
             }

--- a/XenonUtils/image.h
+++ b/XenonUtils/image.h
@@ -11,6 +11,9 @@ struct Image
     size_t base{};
     uint32_t size{};
 
+    uint32_t resource_offset{};
+    uint32_t resource_size{};
+
     size_t entry_point{};
     std::set<Section, SectionComparer> sections{};
     SymbolTable symbols{};

--- a/XenonUtils/xbox.h
+++ b/XenonUtils/xbox.h
@@ -93,6 +93,32 @@ struct be
         set(v);
         return *this;
     }
+
+    be& operator++ ()
+    {
+        set(get() + 1);
+        return *this;
+    }
+
+    be operator++ (int)
+    {
+        be old = *this;
+        set(get() + 1);
+        return old;
+    }
+
+    be& operator-- ()
+    {
+        set(get() - 1);
+        return *this;
+    }
+
+    be operator-- (int)
+    {
+        be old = *this;
+        set(get() - 1);
+        return old;
+    }
 };
 
 extern "C" void* MmGetHostAddress(uint32_t ptr);
@@ -198,13 +224,12 @@ typedef struct _XDISPATCHER_HEADER
     XLIST_ENTRY WaitListHead;
 } XDISPATCHER_HEADER, * XPDISPATCHER_HEADER;
 
-// These variables are never accessed in guest code, we can safely use them in little endian
 typedef struct _XRTL_CRITICAL_SECTION
 {
     XDISPATCHER_HEADER Header;
-    int32_t LockCount;
-    int32_t RecursionCount;
-    uint32_t OwningThread;
+    be<int32_t> LockCount;
+    be<int32_t> RecursionCount;
+    be<uint32_t> OwningThread;
 } XRTL_CRITICAL_SECTION;
 
 typedef struct _XANSI_STRING {

--- a/XenonUtils/xex.cpp
+++ b/XenonUtils/xex.cpp
@@ -258,7 +258,7 @@ Image Xex2LoadImage(const uint8_t* data, size_t dataSize)
     }
 
     image.data = std::move(result);
-    image.size = security->imageSize;
+    image.size = imageSize;
 
     // Map image
     const auto* dosHeader = reinterpret_cast<IMAGE_DOS_HEADER*>(image.data.get());
@@ -269,6 +269,13 @@ Image Xex2LoadImage(const uint8_t* data, size_t dataSize)
     if (xex2BaseAddressPtr != nullptr)
     {
         image.base = *reinterpret_cast<const be<uint32_t>*>(xex2BaseAddressPtr);
+    }
+    const void* xex2ResourceInfoPtr = getOptHeaderPtr(data, XEX_HEADER_RESOURCE_INFO);
+    if (xex2ResourceInfoPtr != nullptr)
+    {
+        const Xex2ResourceInfo* resourceInfo = reinterpret_cast<const Xex2ResourceInfo*>(xex2ResourceInfoPtr);
+        image.resource_offset = resourceInfo->offset;
+        image.resource_size = resourceInfo->sizeOfData;
     }
     const void* xex2EntryPointPtr = getOptHeaderPtr(data, XEX_HEADER_ENTRY_POINT);
     if (xex2EntryPointPtr != nullptr)


### PR DESCRIPTION
* Use big endian for `XRTL_CRITICAL_SECTION` fields. The current code assumes these are not accessed by the game, but they can be, for example in Sonic '06. I also added prefix and postfix operators to the big-endian wrapper to account for some of the current uses of these fields in projects.
* Fix image size for basic compressed XEX. The size from the security info was being used instead of the updated `imageSize` from the decompression process.
* Expose resource info in the `Image` output from `Image::ParseImage`. This makes it sufficient to use for loading the XEX when recomp starts instead of duplicating code.
* Fix compiler warnings about comparing `uint32_t` values to `NULL` in the recompiler.